### PR TITLE
Do not hardcode commit hash for dcat extension

### DIFF
--- a/ckan/extensions/dcat.sls
+++ b/ckan/extensions/dcat.sls
@@ -7,6 +7,5 @@ include:
 dcat:
   ckanext.installed:
     - requirements_file: 'requirements.txt'
-    - rev: '54f6366a5c6368e70cc136b32fe7b2006f30ee27'
     - require:
       - virtualenv: {{ ckan.venv_path }}

--- a/pillar.example
+++ b/pillar.example
@@ -27,6 +27,7 @@ ckan:
           ckan.harvest.mq.type: redis
       dcat:
         repourl: https://github.com/ckan/ckanext-dcat
+        rev: '54f6366a5c6368e70cc136b32fe7b2006f30ee27'
         plugins:
           - dcat
           - dcat_rdf_harvester


### PR DESCRIPTION
Installing DCAT extension from the formula is achieved by default with a
clone of the extension's Github repository. Moreover, the revision to
use is hardcoded in the formula.

However, one may want to install a fork of the extension instead, thus
the revision to use may be different. We remove it from the formula, and
document that a specific revision can be specified using pillars (if not
specified, head of master branch will be used).
